### PR TITLE
feat: install or uninstall multiple extensions in one command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,4 +38,6 @@ jobs:
           fish -n completions/phpenv.fish
 
       - name: Run tests
-        run: fish tests/version-detection.fish
+        run: |
+          fish tests/version-detection.fish
+          fish tests/extensions.fish

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ phpenv global 8.3
 phpenv local 8.1
 
 # Install extensions
-phpenv extensions install xdebug
-phpenv extensions install redis
+phpenv extensions install xdebug redis
 
 # Configure behavior
 phpenv config set auto-switch false  # Disable auto-switching
@@ -102,8 +101,8 @@ phpenv doctor
 
 ### Extension Management
 
-- `phpenv extensions install <ext>` - Install extension for current PHP
-- `phpenv extensions uninstall <ext>` - Uninstall extension
+- `phpenv extensions install <ext> [ext ...]` - Install one or more extensions for current PHP
+- `phpenv extensions uninstall <ext> [ext ...]` - Uninstall one or more extensions
 - `phpenv extensions list` - List installed extensions
 - `phpenv extensions available` - Show available extensions
 

--- a/functions/phpenv.fish
+++ b/functions/phpenv.fish
@@ -1465,25 +1465,25 @@ function __phpenv_config_list
     __phpenv_config_get default-extensions --verbose
 end
 
-function __phpenv_extensions -a phpenv_action phpenv_extension
+function __phpenv_extensions -a phpenv_action
     switch $phpenv_action
         case install
-            __phpenv_extensions_install $phpenv_extension
+            __phpenv_extensions_install $argv[2..]
         case uninstall remove
-            __phpenv_extensions_uninstall $phpenv_extension
+            __phpenv_extensions_uninstall $argv[2..]
         case list ls
             __phpenv_extensions_list
         case available
             __phpenv_extensions_available
         case '*'
-            echo "Usage: phpenv extensions {install|uninstall|list|available} [extension]"
+            echo "Usage: phpenv extensions {install|uninstall|list|available} [extension ...]"
             return 1
     end
 end
 
-function __phpenv_extensions_install -a phpenv_extension
-    if test -z "$phpenv_extension"
-        echo "Usage: phpenv extensions install <extension>"
+function __phpenv_extensions_install
+    if test (count $argv) -eq 0
+        echo "Usage: phpenv extensions install <extension> [extension ...]"
         return 1
     end
 
@@ -1499,24 +1499,37 @@ function __phpenv_extensions_install -a phpenv_extension
         return 1
     end
 
-    echo "Installing $phpenv_extension for PHP $phpenv_version..."
-
     set -l provider (__phpenv_get_provider)
+    if not contains -- $provider homebrew apt
+        echo "Unknown provider: $provider"
+        return 1
+    end
 
-    switch $provider
-        case homebrew
-            __phpenv_provider_homebrew_ext_install $phpenv_extension $phpenv_version
-        case apt
-            __phpenv_provider_apt_ext_install $phpenv_extension $phpenv_version
-        case '*'
-            echo "Unknown provider: $provider"
-            return 1
+    set -l phpenv_failed
+    for phpenv_extension in $argv
+        echo "Installing $phpenv_extension for PHP $phpenv_version..."
+
+        switch $provider
+            case homebrew
+                __phpenv_provider_homebrew_ext_install $phpenv_extension $phpenv_version
+            case apt
+                __phpenv_provider_apt_ext_install $phpenv_extension $phpenv_version
+        end
+
+        if test $status -ne 0
+            set -a phpenv_failed $phpenv_extension
+        end
+    end
+
+    if test (count $phpenv_failed) -gt 0
+        echo "Failed to install: "(string join ", " $phpenv_failed)
+        return 1
     end
 end
 
-function __phpenv_extensions_uninstall -a phpenv_extension
-    if test -z "$phpenv_extension"
-        echo "Usage: phpenv extensions uninstall <extension>"
+function __phpenv_extensions_uninstall
+    if test (count $argv) -eq 0
+        echo "Usage: phpenv extensions uninstall <extension> [extension ...]"
         return 1
     end
 
@@ -1527,15 +1540,28 @@ function __phpenv_extensions_uninstall -a phpenv_extension
     end
 
     set -l provider (__phpenv_get_provider)
+    if not contains -- $provider homebrew apt
+        echo "Unknown provider: $provider"
+        return 1
+    end
 
-    switch $provider
-        case homebrew
-            __phpenv_provider_homebrew_ext_uninstall $phpenv_extension $phpenv_version
-        case apt
-            __phpenv_provider_apt_ext_uninstall $phpenv_extension $phpenv_version
-        case '*'
-            echo "Unknown provider: $provider"
-            return 1
+    set -l phpenv_failed
+    for phpenv_extension in $argv
+        switch $provider
+            case homebrew
+                __phpenv_provider_homebrew_ext_uninstall $phpenv_extension $phpenv_version
+            case apt
+                __phpenv_provider_apt_ext_uninstall $phpenv_extension $phpenv_version
+        end
+
+        if test $status -ne 0
+            set -a phpenv_failed $phpenv_extension
+        end
+    end
+
+    if test (count $phpenv_failed) -gt 0
+        echo "Failed to uninstall: "(string join ", " $phpenv_failed)
+        return 1
     end
 end
 

--- a/tests/extensions.fish
+++ b/tests/extensions.fish
@@ -1,0 +1,75 @@
+#!/usr/bin/env fish
+# Multi-extension install/uninstall checks (providers stubbed).
+# Run: fish tests/extensions.fish
+
+set -l repo_root (dirname (status dirname))
+source $repo_root/functions/phpenv.fish
+
+# Keep the PWD event handler quiet while the test runs
+set -g PHPENV_AUTO_SWITCH false
+set -g test_failures 0
+
+function assert_eq -a actual expected label
+    if test "$actual" = "$expected"
+        echo "ok   $label"
+    else
+        echo "FAIL $label: expected '$expected', got '$actual'"
+        set -g test_failures (math $test_failures + 1)
+    end
+end
+
+# --- provider stubs: record calls, fail on 'badext' -------------------------
+function __phpenv_get_provider
+    echo apt
+end
+function __phpenv_detect_version
+    echo 8.3
+end
+set -g stub_installed
+function __phpenv_provider_apt_ext_install -a ext ver
+    set -a stub_installed "$ext@$ver"
+    test "$ext" != badext
+end
+function __phpenv_provider_apt_ext_uninstall -a ext ver
+    test "$ext" != badext
+end
+
+# --- install: multiple extensions in one call -------------------------------
+set stub_installed
+phpenv ext install ext1 ext2 ext3 >/dev/null
+assert_eq $status 0 "multi-install exits 0"
+assert_eq "$stub_installed" "ext1@8.3 ext2@8.3 ext3@8.3" "multi-install installs all three"
+
+# --- install: one failure -> nonzero, remaining still attempted -------------
+set stub_installed
+set -l out (phpenv ext install ext1 badext ext2)
+assert_eq $status 1 "partial failure exits 1"
+assert_eq "$stub_installed" "ext1@8.3 badext@8.3 ext2@8.3" "failure does not stop the loop"
+if string match -q "*Failed to install: badext*" "$out"
+    echo "ok   failure summary names badext"
+else
+    echo "FAIL failure summary: got '$out'"
+    set -g test_failures (math $test_failures + 1)
+end
+
+# --- install: no args -> usage error ----------------------------------------
+phpenv ext install >/dev/null
+assert_eq $status 1 "install with no args exits 1"
+
+# --- install: single extension still works (default-extensions path) --------
+set stub_installed
+phpenv ext install ext1 >/dev/null
+assert_eq $status 0 "single install exits 0"
+assert_eq "$stub_installed" "ext1@8.3" "single install installs one"
+
+# --- uninstall: multiple, with and without failure ---------------------------
+phpenv ext uninstall ext1 ext2 >/dev/null
+assert_eq $status 0 "multi-uninstall exits 0"
+phpenv ext uninstall ext1 badext >/dev/null
+assert_eq $status 1 "multi-uninstall with failure exits 1"
+
+if test $test_failures -gt 0
+    echo "$test_failures test(s) failed"
+    exit 1
+end
+echo "All tests passed"


### PR DESCRIPTION
## Summary
- `phpenv ext install ext1 ext2 ext3` installs all listed extensions in one call: version detected once, each extension attempted even if an earlier one fails, failures collected into a `Failed to install: ...` summary with exit status 1
- `phpenv ext uninstall` gets the same multi-argument handling (the dispatcher now passes all args through, so it would otherwise silently drop extras)
- Single-argument callers (default-extensions auto-install) are unaffected
- Tab completions already handle multiple extension names for free

## Testing
- New `tests/extensions.fish` with stubbed providers: multi-install, partial failure, no-args, single install, multi-uninstall — wired into CI
- `fish tests/version-detection.fish` still passes; `fish -n` syntax checks clean