### PR TITLE
feat: add laravel and from-composer extension install shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ phpenv local 8.1
 # Install extensions
 phpenv extensions install xdebug redis
 
+# Install extension sets
+phpenv extensions install laravel        # extensions used by Laravel Sail
+phpenv extensions install from-composer  # ext-* requirements from composer.json
+
 # Configure behavior
 phpenv config set auto-switch false  # Disable auto-switching
 phpenv config set auto-install true  # Enable auto-installation
@@ -102,6 +106,8 @@ phpenv doctor
 ### Extension Management
 
 - `phpenv extensions install <ext> [ext ...]` - Install one or more extensions for current PHP
+- `phpenv extensions install laravel` - Install the extension set used by [Laravel Sail](https://github.com/laravel/sail)
+- `phpenv extensions install from-composer` - Install `ext-*` requirements from the nearest composer.json
 - `phpenv extensions uninstall <ext> [ext ...]` - Uninstall one or more extensions
 - `phpenv extensions list` - List installed extensions
 - `phpenv extensions available` - Show available extensions

--- a/completions/phpenv.fish
+++ b/completions/phpenv.fish
@@ -113,10 +113,16 @@ complete -c phpenv -f \
     -n "not __fish_seen_subcommand_from install uninstall remove list ls available" \
     -a "available" -d "Show available extensions"
 
-# Complete extension names
+# Complete extension names and install shortcuts
 complete -c phpenv -f \
     -n "__fish_seen_subcommand_from extensions ext; and __fish_seen_subcommand_from install" \
     -a "(__phpenv_complete_extensions)" -d "PHP extension"
+complete -c phpenv -f \
+    -n "__fish_seen_subcommand_from extensions ext; and __fish_seen_subcommand_from install" \
+    -a "laravel" -d "Extensions used by Laravel Sail"
+complete -c phpenv -f \
+    -n "__fish_seen_subcommand_from extensions ext; and __fish_seen_subcommand_from install" \
+    -a "from-composer" -d "ext-* requirements from composer.json"
 
 # Complete help options
 complete -c phpenv -f -s h -l help -d "Show help"

--- a/functions/phpenv.fish
+++ b/functions/phpenv.fish
@@ -1488,15 +1488,23 @@ set -g __phpenv_preset_laravel bcmath curl gd igbinary imagick imap intl ldap mb
     memcached mongodb msgpack mysql pcov pgsql redis soap sqlite3 swoole xdebug xml zip
 
 # Print ext-* requirements from the nearest composer.json (require + require-dev),
-# mapped to provider package names. Returns 1 if no composer.json is found.
+# mapped to provider package names. Stays silent on errors because callers run it
+# in a command substitution (fish routes nested-substitution stderr straight to the
+# session tty, bypassing caller redirections): returns 1 if no composer.json is
+# found, 2 if it cannot be parsed; the caller reports.
 function __phpenv_composer_required_extensions
     set -l phpenv_composer_file (__phpenv_find_version_file composer.json)
     if test -z "$phpenv_composer_file"
         return 1
     end
 
-    for phpenv_ext in (jq -r '((.require // {}) + (."require-dev" // {}))
+    set -l phpenv_composer_exts (jq -r '((.require // {}) + (."require-dev" // {}))
             | keys[] | select(startswith("ext-")) | ltrimstr("ext-")' "$phpenv_composer_file" 2>/dev/null)
+    if test $status -ne 0
+        return 2
+    end
+
+    for phpenv_ext in $phpenv_composer_exts
         switch $phpenv_ext
             # Bundled with every PHP the providers ship; nothing to install
             case json ctype filter hash openssl pcre session spl tokenizer fileinfo iconv phar posix pdo sodium
@@ -1530,9 +1538,13 @@ function __phpenv_extensions_install
                 set -a phpenv_extensions $__phpenv_preset_laravel
             case from-composer
                 set -l phpenv_composer_exts (__phpenv_composer_required_extensions)
-                if test $status -ne 0
-                    echo "No composer.json found"
-                    return 1
+                switch $status
+                    case 1
+                        echo "No composer.json found" >&2
+                        return 1
+                    case 2
+                        echo "Failed to parse composer.json" >&2
+                        return 1
                 end
                 if test (count $phpenv_composer_exts) -eq 0
                     echo "No ext-* requirements found in composer.json"

--- a/functions/phpenv.fish
+++ b/functions/phpenv.fish
@@ -1481,10 +1481,72 @@ function __phpenv_extensions -a phpenv_action
     end
 end
 
+# Extension set from laravel/sail runtimes/<ver>/Dockerfile (identical for 8.0-8.5),
+# minus non-extension packages (cli, dev, readline). Single shared list;
+# split per PHP version if sail's runtimes ever diverge.
+set -g __phpenv_preset_laravel bcmath curl gd igbinary imagick imap intl ldap mbstring \
+    memcached mongodb msgpack mysql pcov pgsql redis soap sqlite3 swoole xdebug xml zip
+
+# Print ext-* requirements from the nearest composer.json (require + require-dev),
+# mapped to provider package names. Returns 1 if no composer.json is found.
+function __phpenv_composer_required_extensions
+    set -l phpenv_composer_file (__phpenv_find_version_file composer.json)
+    if test -z "$phpenv_composer_file"
+        return 1
+    end
+
+    for phpenv_ext in (jq -r '((.require // {}) + (."require-dev" // {}))
+            | keys[] | select(startswith("ext-")) | ltrimstr("ext-")' "$phpenv_composer_file" 2>/dev/null)
+        switch $phpenv_ext
+            # Bundled with every PHP the providers ship; nothing to install
+            case json ctype filter hash openssl pcre session spl tokenizer fileinfo iconv phar posix pdo sodium
+                continue
+            # Provider packages bundle these under a different name
+            case dom simplexml xmlreader xmlwriter
+                echo xml
+            case mysqli pdo_mysql
+                echo mysql
+            case pdo_pgsql
+                echo pgsql
+            case pdo_sqlite
+                echo sqlite3
+            case '*'
+                echo $phpenv_ext
+        end
+    end
+end
+
 function __phpenv_extensions_install
     if test (count $argv) -eq 0
-        echo "Usage: phpenv extensions install <extension> [extension ...]"
+        echo "Usage: phpenv extensions install <extension|laravel|from-composer> [extension ...]"
         return 1
+    end
+
+    # Expand shortcuts (framework presets, composer.json scan) and dedupe
+    set -l phpenv_extensions
+    for phpenv_arg in $argv
+        switch $phpenv_arg
+            case laravel
+                set -a phpenv_extensions $__phpenv_preset_laravel
+            case from-composer
+                set -l phpenv_composer_exts (__phpenv_composer_required_extensions)
+                if test $status -ne 0
+                    echo "No composer.json found"
+                    return 1
+                end
+                if test (count $phpenv_composer_exts) -eq 0
+                    echo "No ext-* requirements found in composer.json"
+                    continue
+                end
+                set -a phpenv_extensions $phpenv_composer_exts
+            case '*'
+                set -a phpenv_extensions $phpenv_arg
+        end
+    end
+    set phpenv_extensions (printf '%s\n' $phpenv_extensions | awk '!seen[$0]++')
+    if test (count $phpenv_extensions) -eq 0
+        echo "Nothing to install"
+        return 0
     end
 
     # Check for version override first (from environment, not global variable)
@@ -1506,7 +1568,7 @@ function __phpenv_extensions_install
     end
 
     set -l phpenv_failed
-    for phpenv_extension in $argv
+    for phpenv_extension in $phpenv_extensions
         echo "Installing $phpenv_extension for PHP $phpenv_version..."
 
         switch $provider
@@ -1725,6 +1787,8 @@ function __phpenv_help
     echo "  doctor                  Check phpenv installation and provider"
     echo "  config <action>         Manage configuration"
     echo "  extensions <action>     Manage PHP extensions"
+    echo "                          install shortcuts: 'laravel' (Laravel Sail set),"
+    echo "                          'from-composer' (ext-* from composer.json)"
     echo "  help                    Show this help"
     echo ""
     echo "Version sources (in order of priority):"

--- a/tests/extensions.fish
+++ b/tests/extensions.fish
@@ -68,6 +68,61 @@ assert_eq $status 0 "multi-uninstall exits 0"
 phpenv ext uninstall ext1 badext >/dev/null
 assert_eq $status 1 "multi-uninstall with failure exits 1"
 
+# --- laravel preset -----------------------------------------------------------
+set stub_installed
+phpenv ext install laravel >/dev/null
+assert_eq $status 0 "laravel preset exits 0"
+assert_eq (count $stub_installed) (count $__phpenv_preset_laravel) "laravel preset installs full set"
+if contains -- "redis@8.3" $stub_installed; and contains -- "xdebug@8.3" $stub_installed
+    echo "ok   laravel preset includes redis and xdebug"
+else
+    echo "FAIL laravel preset missing expected extensions: $stub_installed"
+    set -g test_failures (math $test_failures + 1)
+end
+if contains -- "cli@8.3" $stub_installed; or contains -- "dev@8.3" $stub_installed
+    echo "FAIL laravel preset contains non-extension packages"
+    set -g test_failures (math $test_failures + 1)
+else
+    echo "ok   laravel preset excludes cli/dev packages"
+end
+
+# --- preset + explicit extension dedupes ---------------------------------------
+set stub_installed
+phpenv ext install laravel redis >/dev/null
+assert_eq (count $stub_installed) (count $__phpenv_preset_laravel) "laravel + redis dedupes"
+
+# --- from-composer -------------------------------------------------------------
+set -l sandbox (mktemp -d)
+echo '{
+  "require": {
+    "php": "^8.2",
+    "ext-json": "*",
+    "ext-redis": "*",
+    "ext-mysqli": "*",
+    "ext-dom": "*",
+    "ext-simplexml": "*"
+  },
+  "require-dev": {
+    "ext-pcov": "*"
+  }
+}' >$sandbox/composer.json
+
+pushd $sandbox
+set stub_installed
+phpenv ext install from-composer >/dev/null
+assert_eq $status 0 "from-composer exits 0"
+assert_eq "$stub_installed" "xml@8.3 mysql@8.3 pcov@8.3 redis@8.3" \
+    "from-composer maps aliases, skips built-ins, dedupes"
+popd
+
+# --- from-composer without composer.json ---------------------------------------
+set -l empty_sandbox (mktemp -d)
+pushd $empty_sandbox
+phpenv ext install from-composer >/dev/null
+assert_eq $status 1 "from-composer without composer.json exits 1"
+popd
+rm -rf $sandbox $empty_sandbox
+
 if test $test_failures -gt 0
     echo "$test_failures test(s) failed"
     exit 1

--- a/tests/extensions.fish
+++ b/tests/extensions.fish
@@ -118,10 +118,25 @@ popd
 # --- from-composer without composer.json ---------------------------------------
 set -l empty_sandbox (mktemp -d)
 pushd $empty_sandbox
-phpenv ext install from-composer >/dev/null
+set -l err (phpenv ext install from-composer 2>&1 >/dev/null)
 assert_eq $status 1 "from-composer without composer.json exits 1"
+assert_eq "$err" "No composer.json found" "missing composer.json reported on stderr"
 popd
-rm -rf $sandbox $empty_sandbox
+
+# --- from-composer with malformed composer.json ---------------------------------
+set -l broken_sandbox (mktemp -d)
+echo 'not json{' >$broken_sandbox/composer.json
+pushd $broken_sandbox
+set -l err (phpenv ext install from-composer 2>&1 >/dev/null)
+assert_eq $status 1 "from-composer with malformed composer.json exits 1"
+if string match -q "Failed to parse *" "$err"
+    echo "ok   parse failure reported on stderr"
+else
+    echo "FAIL parse failure message: got '$err'"
+    set -g test_failures (math $test_failures + 1)
+end
+popd
+rm -rf $sandbox $empty_sandbox $broken_sandbox
 
 if test $test_failures -gt 0
     echo "$test_failures test(s) failed"


### PR DESCRIPTION
## Summary
- `phpenv ext install laravel` installs the extension set used by [Laravel Sail](https://github.com/laravel/sail): the package list extracted from `runtimes/<ver>/Dockerfile` is identical across 8.0–8.5, so it's one shared list (bcmath, curl, gd, igbinary, imagick, imap, intl, ldap, mbstring, memcached, mongodb, msgpack, mysql, pcov, pgsql, redis, soap, sqlite3, swoole, xdebug, xml, zip), excluding Sail's non-extension packages (`cli`, `dev`, `readline`)
- `phpenv ext install from-composer` scans the nearest composer.json (upward search, same as version detection) for `ext-*` keys in `require` + `require-dev`, skips extensions bundled with every provider build (json, ctype, openssl, …), and maps composer names to provider package names (`mysqli`/`pdo_mysql` → mysql, `dom`/`simplexml`/`xmlreader`/`xmlwriter` → xml, `pdo_pgsql` → pgsql, `pdo_sqlite` → sqlite3)
- Shortcuts compose with plain extension names (`phpenv ext install laravel redis`); the expanded list is deduped before installing
- Tab completions offer both shortcuts; help text and README updated

## Testing
- 8 new assertions in `tests/extensions.fish` (stubbed providers): preset contents, cli/dev exclusion, dedupe, composer alias/skip mapping, missing-composer.json error
- Both suites pass; `fish -n` syntax checks clean