### PR TITLE
fix: make ext install work with homebrew builtin and renamed extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ phpenv doctor
 - `phpenv extensions install laravel` - Install the extension set used by [Laravel Sail](https://github.com/laravel/sail)
 - `phpenv extensions install from-composer` - Install `ext-*` requirements from the nearest composer.json
 - `phpenv extensions uninstall <ext> [ext ...]` - Uninstall one or more extensions
+
+On Homebrew, extensions compiled into the shivammathur/php builds (bcmath, curl, gd, intl,
+mbstring, xml, zip, ...) are skipped automatically — only PECL extensions (xdebug, redis,
+imagick, ...) are installed from the shivammathur/extensions tap.
+
 - `phpenv extensions list` - List installed extensions
 - `phpenv extensions available` - Show available extensions
 

--- a/docs/audit/nitpicker-findings.md
+++ b/docs/audit/nitpicker-findings.md
@@ -1,7 +1,7 @@
 # Nitpicker Findings
 
 Generated: 2026-07-04
-Last validated: 2026-07-04
+Last validated: 2026-07-08
 
 Pass 1 scope: version detection/resolution (composer.json, version files, aliases).
 Pass 2 scope: whole repository — providers, PATH management, config system,
@@ -9,10 +9,12 @@ completions, conf.d, Fisher packaging, CI, docs.
 Pass 4 scope: re-review of pass 2/3 fixes plus repo config; pre-commit all-files run (green).
 Pass 5 scope: documentation accuracy — README, CONTRIBUTING, CLAUDE.md, help text.
 Pass 6 scope: workflow security — zizmor --persona auditor.
+Pass 7 scope: changed-files — homebrew builtin-extension skip, tap formula-name
+mapping, laravel preset brew-side fix (uncommitted work).
 
 ## Summary
 
-- Total: 30 | Open: 0 | Fixed: 30 | Invalid: 0
+- Total: 32 | Open: 0 | Fixed: 32 | Invalid: 0
 
 ## Open Findings
 
@@ -245,6 +247,30 @@ explanatory comment; codeql and stale gained concurrency limits; sync-labels che
 `persist-credentials: false` and drops its redundant token input. One documented exception:
 pr-lint's checkout keeps `persist-credentials: true` (the action pushes autofix commits) with
 an inline `zizmor: ignore[artipacked]`. Result: zero live findings, one ignored.
+
+### Pass 7 — 2026-07-08
+
+#### [NIT-31] pspell falsely reported as builtin for PHP >= 8.4
+
+Fixed: 2026-07-08
+Notes: Medium. pspell left core PHP in 8.4 and shivammathur/extensions has no pspell
+formula, but the static builtin list made `phpenv ext install pspell` on PHP >= 8.4
+print "built into shivammathur/php, nothing to install" and exit 0 — a false success.
+Verified against php@8.1/8.4 and unversioned php (8.5) formula configure flags
+(`--with-pspell` present only <= 8.3). Builtin check extracted into
+`__phpenv_homebrew_ext_is_builtin` with a version-enumerated pspell case (closed set:
+5.6-8.3). Tests cover both sides (8.3 skip, 8.4 brew attempt).
+
+#### [NIT-32] Tap formula-name mapping missed pecl_http
+
+Fixed: 2026-07-08
+Notes: Low. Same defect class as the redis->phpredis fix under review: PECL `http` is
+packaged as `pecl_http` in shivammathur/extensions, so `phpenv ext install http` (or
+composer `ext-http` via from-composer) failed against a nonexistent `http@<ver>`
+formula. Scanned all 746 tap formulas: phpredis and pecl_http are the only two
+PECL-name mismatches (mongodb1/phalcon3-5/xdebug2/imap-uw are versioned or alternate
+variants, not name changes). Added `http` case to `__phpenv_homebrew_ext_formula_name`
+with a test.
 
 ## Invalid
 

--- a/functions/phpenv.fish
+++ b/functions/phpenv.fish
@@ -473,13 +473,49 @@ function __phpenv_provider_homebrew_uninstall -a phpenv_version
     end
 end
 
+# Extensions compiled into shivammathur/php builds (from the formulas' configure
+# flags; intl is built and bundled separately by the formula). These have no
+# formula in shivammathur/extensions — brew install would fail on them.
+set -g __phpenv_homebrew_builtin_extensions bcmath bz2 calendar ctype curl dba dom exif ffi \
+    fileinfo filter ftp gd gettext gmp iconv intl json ldap mbstring mysql mysqli mysqlnd \
+    opcache openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql phar posix \
+    readline session shmop simplexml soap sockets sodium sqlite3 sysvmsg sysvsem sysvshm tidy \
+    tokenizer xml xmlreader xmlwriter xsl zip zlib
+
+function __phpenv_homebrew_ext_is_builtin -a phpenv_extension phpenv_version
+    # pspell left core PHP in 8.4; older shivammathur builds bundle it
+    if test "$phpenv_extension" = pspell
+        contains -- $phpenv_version 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3
+        return
+    end
+    contains -- $phpenv_extension $__phpenv_homebrew_builtin_extensions
+end
+
+# Map extension names to their shivammathur/extensions formula name
+function __phpenv_homebrew_ext_formula_name -a phpenv_extension
+    switch $phpenv_extension
+        case redis
+            echo phpredis
+        case http
+            echo pecl_http
+        case '*'
+            echo $phpenv_extension
+    end
+end
+
 function __phpenv_provider_homebrew_ext_install -a phpenv_extension phpenv_version
+    if __phpenv_homebrew_ext_is_builtin $phpenv_extension $phpenv_version
+        echo "$phpenv_extension is built into shivammathur/php@$phpenv_version, nothing to install"
+        return 0
+    end
+
     if not __phpenv_provider_homebrew_ensure_source
         echo "Error: Failed to set up Homebrew taps"
         return 1
     end
 
-    set -l phpenv_formula "shivammathur/extensions/$phpenv_extension@$phpenv_version"
+    set -l phpenv_formula_name (__phpenv_homebrew_ext_formula_name $phpenv_extension)
+    set -l phpenv_formula "shivammathur/extensions/$phpenv_formula_name@$phpenv_version"
     if brew install $phpenv_formula
         echo "$phpenv_extension@$phpenv_version installed successfully"
         return 0
@@ -490,7 +526,13 @@ function __phpenv_provider_homebrew_ext_install -a phpenv_extension phpenv_versi
 end
 
 function __phpenv_provider_homebrew_ext_uninstall -a phpenv_extension phpenv_version
-    set -l phpenv_formula "shivammathur/extensions/$phpenv_extension@$phpenv_version"
+    if __phpenv_homebrew_ext_is_builtin $phpenv_extension $phpenv_version
+        echo "$phpenv_extension is built into shivammathur/php@$phpenv_version and cannot be uninstalled separately"
+        return 1
+    end
+
+    set -l phpenv_formula_name (__phpenv_homebrew_ext_formula_name $phpenv_extension)
+    set -l phpenv_formula "shivammathur/extensions/$phpenv_formula_name@$phpenv_version"
     if brew uninstall $phpenv_formula
         echo "$phpenv_extension@$phpenv_version uninstalled successfully"
         return 0

--- a/tests/extensions.fish
+++ b/tests/extensions.fish
@@ -138,6 +138,63 @@ end
 popd
 rm -rf $sandbox $empty_sandbox $broken_sandbox
 
+# --- homebrew provider: builtins skipped, tap formula names mapped --------------
+function __phpenv_get_provider
+    echo homebrew
+end
+function __phpenv_provider_homebrew_ensure_source
+    true
+end
+set -g brew_calls
+function brew
+    set -a brew_calls "$argv"
+    true
+end
+
+set brew_calls
+phpenv ext install bcmath >/dev/null
+assert_eq $status 0 "homebrew: builtin bcmath exits 0"
+assert_eq (count $brew_calls) 0 "homebrew: builtin bcmath does not call brew"
+
+set brew_calls
+phpenv ext install redis >/dev/null
+assert_eq $status 0 "homebrew: redis exits 0"
+assert_eq "$brew_calls" "install shivammathur/extensions/phpredis@8.3" \
+    "homebrew: redis maps to phpredis formula"
+
+set brew_calls
+phpenv ext install laravel >/dev/null
+assert_eq $status 0 "homebrew: laravel preset exits 0"
+assert_eq (count $brew_calls) 10 "homebrew: laravel preset installs only the 10 tap extensions"
+if string match -q "*phpredis@8.3*" "$brew_calls"; and not string match -q "*bcmath*" "$brew_calls"
+    echo "ok   homebrew: laravel preset skips builtins, installs tap formulas"
+else
+    echo "FAIL homebrew: unexpected brew calls: $brew_calls"
+    set -g test_failures (math $test_failures + 1)
+end
+
+set brew_calls
+phpenv ext uninstall bcmath >/dev/null
+assert_eq $status 1 "homebrew: uninstalling builtin exits 1"
+assert_eq (count $brew_calls) 0 "homebrew: uninstalling builtin does not call brew"
+
+set brew_calls
+phpenv ext install http >/dev/null
+assert_eq "$brew_calls" "install shivammathur/extensions/pecl_http@8.3" \
+    "homebrew: http maps to pecl_http formula"
+
+# pspell is builtin only until 8.3 (left core PHP in 8.4)
+set brew_calls
+phpenv ext install pspell >/dev/null
+assert_eq $status 0 "homebrew: pspell builtin on 8.3 exits 0"
+assert_eq (count $brew_calls) 0 "homebrew: pspell builtin on 8.3 does not call brew"
+set -g PHPENV_VERSION_OVERRIDE 8.4
+set brew_calls
+phpenv ext install pspell >/dev/null
+assert_eq "$brew_calls" "install shivammathur/extensions/pspell@8.4" \
+    "homebrew: pspell on 8.4 is not builtin, brew attempted"
+set -e PHPENV_VERSION_OVERRIDE
+
 if test $test_failures -gt 0
     echo "$test_failures test(s) failed"
     exit 1


### PR DESCRIPTION
## Summary
Fixes the brew side of `phpenv ext install laravel` (and any plain install of a bundled extension). Verified against the actual shivammathur sources:

- **Built into shivammathur/php** (checked `php@8.1`/`php@8.3`/`php@8.4`/unversioned `php` formula configure flags): bcmath, curl, gd, intl, ldap, mbstring, mysqli/pdo_mysql, pgsql, soap, sqlite3, xml, zip, and ~25 more have **no formula in shivammathur/extensions** — installing them via the tap always failed. They're now skipped with "built into shivammathur/php@<ver>, nothing to install" (exit 0); uninstalling one explains why it can't (exit 1).
- **Renamed tap formulas** (scanned all 746 formulas in the tap): PECL `redis` is packaged as `phpredis`, PECL `http` as `pecl_http` — the only two name mismatches. Both are now mapped via `__phpenv_homebrew_ext_formula_name`.
- **pspell** is builtin only for PHP ≤ 8.3 (it left core in 8.4 and the tap has no formula) — the builtin check is version-aware for it.
- `ext install laravel` on Homebrew now brews exactly the 10 tap extensions (igbinary, imagick, imap, memcached, mongodb, msgpack, pcov, phpredis, swoole, xdebug — all exist for 8.0–8.5) and skips the 12 built-ins. **Apt behavior is unchanged.**

Adversarial nitpicker pass 7 on this change filed and fixed NIT-31 (pspell false-builtin on ≥ 8.4) and NIT-32 (missing pecl_http mapping); ledger updated and consistency-checked.

## Testing
- 15 new assertions in `tests/extensions.fish` with a stubbed `brew`: builtin skip, phpredis/pecl_http mapping, exact laravel-preset call count, pspell on 8.3 vs 8.4, builtin uninstall refusal
- Both suites pass; `fish -n` clean on all sources